### PR TITLE
Fix: Install required CMake version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ RUN sdkmanager "platforms;android-34" \
     "build-tools;34.0.0" \
     "platform-tools" \
     "cmdline-tools;latest" \
-    "ndk;21.4.7075529"
+    "ndk;21.4.7075529" \
+    "cmake;3.22.1"
 
 # Install Node.js (you mentioned 16.x as default in your workflow, so this ensures it)
 # The `eclipse-temurin` image usually comes with Java, but we might need to update Node/npm.


### PR DESCRIPTION
Added cmake;3.22.1 to the sdkmanager command in the Dockerfile. This pre-installs the CMake version required by the Inji Wallet build process, aiming to resolve errors where the build (running as a non-root user) failed to install CMake due to a non-writable SDK directory.