### PR TITLE
Fix: Add build-tools;33.0.0 to Dockerfile SDK components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ RUN sdkmanager "platforms;android-34" \
     "platform-tools" \
     "cmdline-tools;latest" \
     "ndk;21.4.7075529" \
-    "cmake;3.22.1"
+    "cmake;3.22.1" \
+    "build-tools;33.0.0"
 
 # Install Node.js (you mentioned 16.x as default in your workflow, so this ensures it)
 # The `eclipse-temurin` image usually comes with Java, but we might need to update Node/npm.


### PR DESCRIPTION
Installed 'build-tools;33.0.0' via sdkmanager in the Dockerfile. This is required by the react-native-flipper dependency and was failing to auto-install due to the SDK directory not being writable by the non-root build user. Pre-installing it resolves this issue.