### PR TITLE
Fix: Add NDK version 23.1.7779620 to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN sdkmanager "platforms;android-34" \
     "platform-tools" \
     "cmdline-tools;latest" \
     "ndk;21.4.7075529" \
+    "ndk;23.1.7779620" \
     "cmake;3.22.1" \
     "build-tools;33.0.0"
 


### PR DESCRIPTION
Installed 'ndk;23.1.7779620' via sdkmanager in the Dockerfile. This specific NDK version is required by the react-native-mmkv-storage dependency and was failing to auto-install due to the SDK directory not being writable by the non-root build user. Pre-installing it resolves this issue. This is in addition to the previously installed NDK 21.4.7075529.