### PR TITLE
Fix: Add build-tools;30.0.3 to Dockerfile SDK components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,8 @@ RUN sdkmanager "platforms;android-34" \
     "ndk;21.4.7075529" \
     "ndk;23.1.7779620" \
     "cmake;3.22.1" \
-    "build-tools;33.0.0"
+    "build-tools;33.0.0" \
+    "build-tools;30.0.3"
 
 # Install Node.js (you mentioned 16.x as default in your workflow, so this ensures it)
 # The `eclipse-temurin` image usually comes with Java, but we might need to update Node/npm.


### PR DESCRIPTION
Installed 'build-tools;30.0.3' via sdkmanager in the Dockerfile. This specific version of build-tools was identified as a requirement during the build process (task :app:compileResidentappDebugJavaWithJavac) and was failing to auto-install due to the SDK directory not being writable by the non-root build user. Pre-installing it resolves this issue.